### PR TITLE
Add dashboard auth API with session-based authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/cli",
+    "crates/server",
     "crates/types",
 ]
 
@@ -9,3 +10,16 @@ members = [
 version = "0.1.0"
 edition = "2024"
 license = "MIT"
+
+[workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+axum = "0.8"
+tower-http = { version = "0.6", features = ["cors"] }
+sha2 = "0.10"
+rand = "0.9"
+subtle = "2"
+chrono = { version = "0.4", features = ["serde"] }
+thiserror = "2"
+dirs = "6"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -9,3 +9,6 @@ name = "fishnet"
 path = "src/main.rs"
 
 [dependencies]
+fishnet-server = { path = "../server" }
+tokio.workspace = true
+axum.workspace = true

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,3 +1,26 @@
-fn main() {
-    println!("fishnet");
+use std::sync::Arc;
+
+use fishnet_server::{
+    create_router,
+    password::FilePasswordStore,
+    rate_limit::LoginRateLimiter,
+    session::SessionStore,
+    state::AppState,
+};
+
+#[tokio::main]
+async fn main() {
+    let state = AppState {
+        password_store: Arc::new(FilePasswordStore::new(FilePasswordStore::default_path())),
+        session_store: Arc::new(SessionStore::new()),
+        rate_limiter: Arc::new(LoginRateLimiter::new()),
+    };
+
+    let app = create_router(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:8473")
+        .await
+        .unwrap();
+    println!("fishnet dashboard API listening on http://127.0.0.1:8473");
+    axum::serve(listener, app).await.unwrap();
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "fishnet-server"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+fishnet-types = { path = "../types" }
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+axum.workspace = true
+tower-http.workspace = true
+sha2.workspace = true
+rand.workspace = true
+subtle.workspace = true
+chrono.workspace = true
+thiserror.workspace = true
+dirs.workspace = true
+
+[dev-dependencies]
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"
+tempfile = "3"

--- a/crates/server/src/auth.rs
+++ b/crates/server/src/auth.rs
@@ -1,0 +1,165 @@
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use fishnet_types::auth::*;
+
+use crate::state::AppState;
+
+pub async fn status(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let initialized = state.password_store.is_initialized().unwrap_or(false);
+
+    let authenticated = if let Some(auth_header) = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+    {
+        if let Some(token) = auth_header.strip_prefix("Bearer ") {
+            state.session_store.validate(token).await
+        } else {
+            false
+        }
+    } else {
+        false
+    };
+
+    Json(AuthStatusResponse {
+        initialized,
+        authenticated,
+    })
+}
+
+pub async fn setup(
+    State(state): State<AppState>,
+    Json(req): Json<SetupRequest>,
+) -> Response {
+    match state.password_store.is_initialized() {
+        Ok(true) => {
+            return (
+                StatusCode::CONFLICT,
+                Json(ErrorResponse {
+                    error: "password already configured".to_string(),
+                    retry_after_seconds: None,
+                }),
+            )
+                .into_response();
+        }
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: format!("internal error: {e}"),
+                    retry_after_seconds: None,
+                }),
+            )
+                .into_response();
+        }
+        _ => {}
+    }
+
+    if req.password != req.confirm {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "passwords do not match".to_string(),
+                retry_after_seconds: None,
+            }),
+        )
+            .into_response();
+    }
+
+    if req.password.len() < 8 {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "password must be at least 8 characters".to_string(),
+                retry_after_seconds: None,
+            }),
+        )
+            .into_response();
+    }
+
+    match state.password_store.setup(&req.password) {
+        Ok(()) => Json(SetupResponse {
+            success: true,
+            message: "password configured successfully".to_string(),
+        })
+        .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!("failed to setup password: {e}"),
+                retry_after_seconds: None,
+            }),
+        )
+            .into_response(),
+    }
+}
+
+pub async fn login(
+    State(state): State<AppState>,
+    Json(req): Json<LoginRequest>,
+) -> Response {
+    if let Err(retry_after) = state.rate_limiter.check_rate_limit().await {
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(ErrorResponse {
+                error: "too many failed login attempts".to_string(),
+                retry_after_seconds: Some(retry_after),
+            }),
+        )
+            .into_response();
+    }
+
+    state.rate_limiter.progressive_delay().await;
+
+    match state.password_store.verify(&req.password) {
+        Ok(true) => {
+            state.rate_limiter.reset().await;
+            let session = state.session_store.create().await;
+            Json(LoginResponse {
+                token: session.token,
+                expires_at: session.expires_at,
+            })
+            .into_response()
+        }
+        Ok(false) => {
+            state.rate_limiter.record_failure().await;
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(ErrorResponse {
+                    error: "invalid password".to_string(),
+                    retry_after_seconds: None,
+                }),
+            )
+                .into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse {
+                error: format!("internal error: {e}"),
+                retry_after_seconds: None,
+            }),
+        )
+            .into_response(),
+    }
+}
+
+pub async fn logout(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    let token = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "))
+        .unwrap_or("");
+
+    state.session_store.remove(token).await;
+
+    Json(LogoutResponse { success: true })
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,0 +1,205 @@
+pub mod auth;
+pub mod middleware;
+pub mod password;
+pub mod rate_limit;
+pub mod session;
+pub mod state;
+
+use axum::{middleware as axum_middleware, routing::{get, post}, Router};
+use tower_http::cors::CorsLayer;
+
+use crate::state::AppState;
+
+pub fn create_router(state: AppState) -> Router {
+    let public_routes = Router::new()
+        .route("/api/auth/status", get(auth::status))
+        .route("/api/auth/setup", post(auth::setup))
+        .route("/api/auth/login", post(auth::login));
+
+    let protected_routes = Router::new()
+        .route("/api/auth/logout", post(auth::logout))
+        .layer(axum_middleware::from_fn_with_state(
+            state.clone(),
+            middleware::require_auth,
+        ));
+
+    Router::new()
+        .merge(public_routes)
+        .merge(protected_routes)
+        .layer(CorsLayer::permissive())
+        .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    use password::FilePasswordStore;
+    use rate_limit::LoginRateLimiter;
+    use session::SessionStore;
+
+    fn test_state(dir: &std::path::Path) -> AppState {
+        AppState {
+            password_store: Arc::new(FilePasswordStore::new(dir.join("auth.json"))),
+            session_store: Arc::new(SessionStore::new()),
+            rate_limiter: Arc::new(LoginRateLimiter::new()),
+        }
+    }
+
+    async fn body_json(body: Body) -> serde_json::Value {
+        let bytes = body.collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    fn status_request() -> Request<Body> {
+        Request::builder()
+            .uri("/api/auth/status")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    fn setup_request(password: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/api/auth/setup")
+            .header("content-type", "application/json")
+            .body(Body::from(format!(
+                r#"{{"password":"{password}","confirm":"{password}"}}"#
+            )))
+            .unwrap()
+    }
+
+    fn login_request(password: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/api/auth/login")
+            .header("content-type", "application/json")
+            .body(Body::from(format!(r#"{{"password":"{password}"}}"#)))
+            .unwrap()
+    }
+
+    fn logout_request(token: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/api/auth/logout")
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_full_auth_flow() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = create_router(test_state(dir.path()));
+
+        // 1. Status: not initialized
+        let resp = app.clone().oneshot(status_request()).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp.into_body()).await;
+        assert_eq!(body["initialized"], false);
+        assert_eq!(body["authenticated"], false);
+
+        // 2. Setup password
+        let resp = app.clone().oneshot(setup_request("test1234")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp.into_body()).await;
+        assert_eq!(body["success"], true);
+
+        // 3. Status: initialized
+        let resp = app.clone().oneshot(status_request()).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp.into_body()).await;
+        assert_eq!(body["initialized"], true);
+
+        // 4. Login
+        let resp = app.clone().oneshot(login_request("test1234")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp.into_body()).await;
+        let token = body["token"].as_str().unwrap().to_string();
+        assert!(token.starts_with("fn_sess_"));
+        assert!(body["expires_at"].is_string());
+
+        // 5. Logout
+        let resp = app.clone().oneshot(logout_request(&token)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_json(resp.into_body()).await;
+        assert_eq!(body["success"], true);
+
+        // 6. Token rejected after logout
+        let resp = app.clone().oneshot(logout_request(&token)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_setup_only_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = create_router(test_state(dir.path()));
+
+        let resp = app.clone().oneshot(setup_request("test1234")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let resp = app.clone().oneshot(setup_request("other123")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_wrong_password() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = create_router(test_state(dir.path()));
+
+        app.clone().oneshot(setup_request("test1234")).await.unwrap();
+
+        let resp = app.clone().oneshot(login_request("wrongpwd")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body = body_json(resp.into_body()).await;
+        assert_eq!(body["error"], "invalid password");
+    }
+
+    #[tokio::test]
+    async fn test_rate_limiting() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = create_router(test_state(dir.path()));
+
+        app.clone().oneshot(setup_request("test1234")).await.unwrap();
+
+        // 5 failed attempts
+        for _ in 0..5 {
+            let resp = app.clone().oneshot(login_request("wrongpwd")).await.unwrap();
+            assert!(
+                resp.status() == StatusCode::UNAUTHORIZED
+                    || resp.status() == StatusCode::TOO_MANY_REQUESTS
+            );
+        }
+
+        // 6th should be rate limited
+        let resp = app.clone().oneshot(login_request("wrongpwd")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        let body = body_json(resp.into_body()).await;
+        assert!(body["retry_after_seconds"].is_number());
+    }
+
+    #[tokio::test]
+    async fn test_protected_without_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let app = create_router(test_state(dir.path()));
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/auth/logout")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/server/src/middleware.rs
+++ b/crates/server/src/middleware.rs
@@ -1,0 +1,48 @@
+use axum::{
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+    Json,
+};
+use fishnet_types::auth::ErrorResponse;
+
+use crate::state::AppState;
+
+pub async fn require_auth(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let auth_header = request
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok());
+
+    let token = match auth_header {
+        Some(h) if h.starts_with("Bearer ") => &h[7..],
+        _ => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                Json(ErrorResponse {
+                    error: "missing or invalid authorization header".to_string(),
+                    retry_after_seconds: None,
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    if !state.session_store.validate(token).await {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse {
+                error: "invalid or expired session token".to_string(),
+                retry_after_seconds: None,
+            }),
+        )
+            .into_response();
+    }
+
+    next.run(request).await
+}

--- a/crates/server/src/password.rs
+++ b/crates/server/src/password.rs
@@ -1,0 +1,123 @@
+use std::fs;
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PasswordError {
+    #[error("password already initialized")]
+    AlreadyInitialized,
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+pub trait PasswordVerifier: Send + Sync {
+    fn is_initialized(&self) -> Result<bool, PasswordError>;
+    fn setup(&self, password: &str) -> Result<(), PasswordError>;
+    fn verify(&self, password: &str) -> Result<bool, PasswordError>;
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct AuthFile {
+    password_hash: String,
+}
+
+pub struct FilePasswordStore {
+    path: PathBuf,
+    cache: RwLock<Option<String>>,
+}
+
+impl FilePasswordStore {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            cache: RwLock::new(None),
+        }
+    }
+
+    pub fn default_path() -> PathBuf {
+        let mut path = dirs::home_dir().expect("could not determine home directory");
+        path.push(".fishnet");
+        path.push("auth.json");
+        path
+    }
+
+    fn hash_password(password: &str) -> String {
+        let hash = Sha256::digest(password.as_bytes());
+        hash.iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    fn read_hash(&self) -> Result<Option<String>, PasswordError> {
+        // Check cache first
+        {
+            let cache = self.cache.read().unwrap();
+            if let Some(ref hash) = *cache {
+                return Ok(Some(hash.clone()));
+            }
+        }
+
+        // Read from file
+        if !self.path.exists() {
+            return Ok(None);
+        }
+
+        let content = fs::read_to_string(&self.path)?;
+        let auth_file: AuthFile = serde_json::from_str(&content)?;
+
+        // Update cache
+        {
+            let mut cache = self.cache.write().unwrap();
+            *cache = Some(auth_file.password_hash.clone());
+        }
+
+        Ok(Some(auth_file.password_hash))
+    }
+}
+
+impl PasswordVerifier for FilePasswordStore {
+    fn is_initialized(&self) -> Result<bool, PasswordError> {
+        Ok(self.read_hash()?.is_some())
+    }
+
+    fn setup(&self, password: &str) -> Result<(), PasswordError> {
+        if self.is_initialized()? {
+            return Err(PasswordError::AlreadyInitialized);
+        }
+
+        let hash = Self::hash_password(password);
+        let auth_file = AuthFile {
+            password_hash: hash.clone(),
+        };
+        let json = serde_json::to_string_pretty(&auth_file)?;
+
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        fs::write(&self.path, json)?;
+
+        let mut cache = self.cache.write().unwrap();
+        *cache = Some(hash);
+
+        Ok(())
+    }
+
+    fn verify(&self, password: &str) -> Result<bool, PasswordError> {
+        let stored = match self.read_hash()? {
+            Some(h) => h,
+            None => return Ok(false),
+        };
+
+        let candidate = Self::hash_password(password);
+        let stored_bytes = stored.as_bytes();
+        let candidate_bytes = candidate.as_bytes();
+
+        Ok(stored_bytes.len() == candidate_bytes.len()
+            && bool::from(stored_bytes.ct_eq(candidate_bytes)))
+    }
+}

--- a/crates/server/src/rate_limit.rs
+++ b/crates/server/src/rate_limit.rs
@@ -1,0 +1,70 @@
+use chrono::{DateTime, TimeDelta, Utc};
+use tokio::sync::Mutex;
+
+pub struct LoginRateLimiter {
+    failures: Mutex<Vec<DateTime<Utc>>>,
+    window: TimeDelta,
+    max_failures: usize,
+}
+
+impl Default for LoginRateLimiter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LoginRateLimiter {
+    pub fn new() -> Self {
+        Self {
+            failures: Mutex::new(Vec::new()),
+            window: TimeDelta::seconds(60),
+            max_failures: 5,
+        }
+    }
+
+    pub async fn check_rate_limit(&self) -> Result<(), u64> {
+        let mut failures = self.failures.lock().await;
+        let now = Utc::now();
+        let cutoff = now - self.window;
+
+        failures.retain(|t| *t > cutoff);
+
+        if failures.len() >= self.max_failures {
+            let oldest = failures.first().unwrap();
+            let retry_after = (*oldest + self.window - now).num_seconds().max(1) as u64;
+            return Err(retry_after);
+        }
+
+        Ok(())
+    }
+
+    pub async fn record_failure(&self) {
+        let mut failures = self.failures.lock().await;
+        failures.push(Utc::now());
+    }
+
+    async fn failure_count(&self) -> usize {
+        let failures = self.failures.lock().await;
+        let now = Utc::now();
+        let cutoff = now - self.window;
+        failures.iter().filter(|t| **t > cutoff).count()
+    }
+
+    pub async fn progressive_delay(&self) {
+        let count = self.failure_count().await;
+        let delay = match count {
+            0..=2 => 0,
+            3 => 1,
+            4 => 2,
+            _ => 5,
+        };
+        if delay > 0 {
+            tokio::time::sleep(std::time::Duration::from_secs(delay)).await;
+        }
+    }
+
+    pub async fn reset(&self) {
+        let mut failures = self.failures.lock().await;
+        failures.clear();
+    }
+}

--- a/crates/server/src/session.rs
+++ b/crates/server/src/session.rs
@@ -1,0 +1,109 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, TimeDelta, Utc};
+use subtle::ConstantTimeEq;
+use tokio::sync::RwLock;
+
+pub struct Session {
+    pub token: String,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+}
+
+pub struct SessionStore {
+    sessions: RwLock<HashMap<String, Session>>,
+    ttl: TimeDelta,
+    max_sessions: usize,
+}
+
+impl Default for SessionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionStore {
+    pub fn new() -> Self {
+        Self {
+            sessions: RwLock::new(HashMap::new()),
+            ttl: TimeDelta::hours(4),
+            max_sessions: 5,
+        }
+    }
+
+    pub async fn create(&self) -> Session {
+        let token_bytes: [u8; 32] = rand::random();
+        let hex: String = token_bytes.iter().map(|b| format!("{b:02x}")).collect();
+        let token = format!("fn_sess_{hex}");
+
+        let now = Utc::now();
+        let expires_at = now + self.ttl;
+
+        let mut sessions = self.sessions.write().await;
+
+        // Remove expired sessions
+        sessions.retain(|_, s| s.expires_at > now);
+
+        // Evict oldest if at max
+        if sessions.len() >= self.max_sessions
+            && let Some(oldest_key) = sessions
+                .iter()
+                .min_by_key(|(_, s)| s.created_at)
+                .map(|(k, _)| k.clone())
+        {
+            sessions.remove(&oldest_key);
+        }
+
+        sessions.insert(
+            token.clone(),
+            Session {
+                token: token.clone(),
+                created_at: now,
+                expires_at,
+            },
+        );
+
+        Session {
+            token,
+            created_at: now,
+            expires_at,
+        }
+    }
+
+    pub async fn validate(&self, token: &str) -> bool {
+        let sessions = self.sessions.read().await;
+        let now = Utc::now();
+
+        for session in sessions.values() {
+            if session.expires_at > now {
+                let stored = session.token.as_bytes();
+                let provided = token.as_bytes();
+                if stored.len() == provided.len() && bool::from(stored.ct_eq(provided)) {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
+    pub async fn remove(&self, token: &str) -> bool {
+        let mut sessions = self.sessions.write().await;
+
+        let key = sessions
+            .keys()
+            .find(|k| {
+                let stored = k.as_bytes();
+                let provided = token.as_bytes();
+                stored.len() == provided.len() && bool::from(stored.ct_eq(provided))
+            })
+            .cloned();
+
+        if let Some(key) = key {
+            sessions.remove(&key);
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -1,0 +1,12 @@
+use std::sync::Arc;
+
+use crate::password::PasswordVerifier;
+use crate::rate_limit::LoginRateLimiter;
+use crate::session::SessionStore;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub password_store: Arc<dyn PasswordVerifier>,
+    pub session_store: Arc<SessionStore>,
+    pub rate_limiter: Arc<LoginRateLimiter>,
+}

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -5,3 +5,5 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+serde.workspace = true
+chrono.workspace = true

--- a/crates/types/src/auth.rs
+++ b/crates/types/src/auth.rs
@@ -1,0 +1,43 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize)]
+pub struct SetupRequest {
+    pub password: String,
+    pub confirm: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LoginRequest {
+    pub password: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AuthStatusResponse {
+    pub initialized: bool,
+    pub authenticated: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SetupResponse {
+    pub success: bool,
+    pub message: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LoginResponse {
+    pub token: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LogoutResponse {
+    pub success: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    pub error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_after_seconds: Option<u64>,
+}

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod auth;

--- a/docs/postman/postman_collection.json
+++ b/docs/postman/postman_collection.json
@@ -1,0 +1,357 @@
+{
+	"info": {
+		"name": "Fishnet API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"description": "Fishnet dashboard API (localhost:8473)"
+	},
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "http://127.0.0.1:8473"
+		},
+		{
+			"key": "token",
+			"value": ""
+		}
+	],
+	"item": [
+		{
+			"name": "Auth",
+			"description": "Authentication endpoints — setup, login, logout, and status checks",
+			"item": [
+				{
+					"name": "Status",
+					"description": "GET /api/auth/status — check initialization and session validity",
+					"item": [
+						{
+							"name": "Status (before setup)",
+							"request": {
+								"method": "GET",
+								"url": {
+									"raw": "{{baseUrl}}/api/auth/status",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "auth", "status"]
+								}
+							},
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status 200', () => pm.response.to.have.status(200));",
+											"",
+											"pm.test('Not initialized, not authenticated', () => {",
+											"    const body = pm.response.json();",
+											"    pm.expect(body.initialized).to.be.false;",
+											"    pm.expect(body.authenticated).to.be.false;",
+											"});"
+										]
+									}
+								}
+							]
+						},
+						{
+							"name": "Status (authenticated)",
+							"request": {
+								"method": "GET",
+								"url": {
+									"raw": "{{baseUrl}}/api/auth/status",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "auth", "status"]
+								},
+								"header": [
+									{ "key": "Authorization", "value": "Bearer {{token}}" }
+								]
+							},
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status 200', () => pm.response.to.have.status(200));",
+											"",
+											"pm.test('Initialized and authenticated', () => {",
+											"    const body = pm.response.json();",
+											"    pm.expect(body.initialized).to.be.true;",
+											"    pm.expect(body.authenticated).to.be.true;",
+											"});"
+										]
+									}
+								}
+							]
+						},
+						{
+							"name": "Status (after logout)",
+							"request": {
+								"method": "GET",
+								"url": {
+									"raw": "{{baseUrl}}/api/auth/status",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "auth", "status"]
+								},
+								"header": [
+									{ "key": "Authorization", "value": "Bearer {{token}}" }
+								]
+							},
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status 200', () => pm.response.to.have.status(200));",
+											"",
+											"pm.test('Initialized but NOT authenticated', () => {",
+											"    const body = pm.response.json();",
+											"    pm.expect(body.initialized).to.be.true;",
+											"    pm.expect(body.authenticated).to.be.false;",
+											"});"
+										]
+									}
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Setup",
+					"description": "POST /api/auth/setup — one-time password configuration",
+					"item": [
+						{
+							"name": "Setup password",
+							"request": {
+								"method": "POST",
+								"url": {
+									"raw": "{{baseUrl}}/api/auth/setup",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "auth", "setup"]
+								},
+								"header": [
+									{ "key": "Content-Type", "value": "application/json" }
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"password\": \"test1234\",\n    \"confirm\": \"test1234\"\n}"
+								}
+							},
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status 200', () => pm.response.to.have.status(200));",
+											"",
+											"pm.test('Setup successful', () => {",
+											"    const body = pm.response.json();",
+											"    pm.expect(body.success).to.be.true;",
+											"    pm.expect(body.message).to.include('configured');",
+											"});"
+										]
+									}
+								}
+							]
+						},
+						{
+							"name": "Setup again (409 conflict)",
+							"request": {
+								"method": "POST",
+								"url": {
+									"raw": "{{baseUrl}}/api/auth/setup",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "auth", "setup"]
+								},
+								"header": [
+									{ "key": "Content-Type", "value": "application/json" }
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"password\": \"other123\",\n    \"confirm\": \"other123\"\n}"
+								}
+							},
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status 409 Conflict', () => pm.response.to.have.status(409));",
+											"",
+											"pm.test('Error message', () => {",
+											"    const body = pm.response.json();",
+											"    pm.expect(body.error).to.include('already configured');",
+											"});"
+										]
+									}
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Login",
+					"description": "POST /api/auth/login — authenticate and receive session token",
+					"item": [
+						{
+							"name": "Login (wrong password)",
+							"request": {
+								"method": "POST",
+								"url": {
+									"raw": "{{baseUrl}}/api/auth/login",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "auth", "login"]
+								},
+								"header": [
+									{ "key": "Content-Type", "value": "application/json" }
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"password\": \"wrongpassword\"\n}"
+								}
+							},
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status 401 Unauthorized', () => pm.response.to.have.status(401));",
+											"",
+											"pm.test('Invalid password error', () => {",
+											"    const body = pm.response.json();",
+											"    pm.expect(body.error).to.eql('invalid password');",
+											"});"
+										]
+									}
+								}
+							]
+						},
+						{
+							"name": "Login (correct password)",
+							"request": {
+								"method": "POST",
+								"url": {
+									"raw": "{{baseUrl}}/api/auth/login",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "auth", "login"]
+								},
+								"header": [
+									{ "key": "Content-Type", "value": "application/json" }
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"password\": \"test1234\"\n}"
+								}
+							},
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status 200', () => pm.response.to.have.status(200));",
+											"",
+											"pm.test('Returns session token', () => {",
+											"    const body = pm.response.json();",
+											"    pm.expect(body.token).to.match(/^fn_sess_/);",
+											"    pm.expect(body.expires_at).to.be.a('string');",
+											"",
+											"    // Save token for subsequent requests",
+											"    pm.collectionVariables.set('token', body.token);",
+											"});"
+										]
+									}
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Logout",
+					"description": "POST /api/auth/logout — invalidate session token (protected)",
+					"item": [
+						{
+							"name": "Logout (no token — 401)",
+							"request": {
+								"method": "POST",
+								"url": {
+									"raw": "{{baseUrl}}/api/auth/logout",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "auth", "logout"]
+								}
+							},
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status 401 Unauthorized', () => pm.response.to.have.status(401));",
+											"",
+											"pm.test('Missing auth header error', () => {",
+											"    const body = pm.response.json();",
+											"    pm.expect(body.error).to.include('authorization header');",
+											"});"
+										]
+									}
+								}
+							]
+						},
+						{
+							"name": "Logout (with token)",
+							"request": {
+								"method": "POST",
+								"url": {
+									"raw": "{{baseUrl}}/api/auth/logout",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "auth", "logout"]
+								},
+								"header": [
+									{ "key": "Authorization", "value": "Bearer {{token}}" }
+								]
+							},
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status 200', () => pm.response.to.have.status(200));",
+											"",
+											"pm.test('Logout successful', () => {",
+											"    const body = pm.response.json();",
+											"    pm.expect(body.success).to.be.true;",
+											"});"
+										]
+									}
+								}
+							]
+						},
+						{
+							"name": "Logout again (token invalidated — 401)",
+							"request": {
+								"method": "POST",
+								"url": {
+									"raw": "{{baseUrl}}/api/auth/logout",
+									"host": ["{{baseUrl}}"],
+									"path": ["api", "auth", "logout"]
+								},
+								"header": [
+									{ "key": "Authorization", "value": "Bearer {{token}}" }
+								]
+							},
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test('Status 401 — token no longer valid', () => pm.response.to.have.status(401));",
+											"",
+											"pm.test('Expired token error', () => {",
+											"    const body = pm.response.json();",
+											"    pm.expect(body.error).to.include('invalid or expired');",
+											"});"
+										]
+									}
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Implement authentication endpoints for the fishnet dashboard API (localhost:8473) with SHA-256 file-based password storage behind swappable PasswordVerifier trait for future Argon2id migration.

Includes rate limiting (5 failures/60s, progressive delay), constant-time token comparison via subtle, CORS permissive layer for Vite dev server, and integration tests using tower::ServiceExt::oneshot.